### PR TITLE
remove unresolve and allow creation of a new comment 

### DIFF
--- a/formatters/githubformat/githubformat.go
+++ b/formatters/githubformat/githubformat.go
@@ -28,8 +28,6 @@ type GitHubClient interface {
 	FileComment(github.NewFileComment) error
 	ResolveFileComment(comment github.Comment) error
 	ResolveComment(comment github.Comment) error
-	UnresolveFileComment(comment github.Comment) error
-	UnresolveComment(comment github.Comment) error
 }
 
 // TODO remove number and sha, use the import instead
@@ -41,7 +39,7 @@ func New(out io.Writer, client GitHubClient) *Formatter {
 	}
 }
 
-var fingerprintRegex = regexp.MustCompile(`(?:<strike>)?<!--\s*(manifest:.*?)\s*-->(?:</strike>)?`)
+var fingerprintRegex = regexp.MustCompile(`<!--\s*(manifest:.*?)\s*-->`)
 
 // BeforeAll grabs the comments in the PR so it can attempt to de-duplicat
 // them.
@@ -99,16 +97,6 @@ func (f *Formatter) Format(source string, i *manifest.Import, r manifest.Result)
 		if ec, ok := f.existingComments[fingerprint]; ok {
 			// This comment won't be marked as resolved because the checker still thinks it's a problem.
 			ec.Stale = false
-			 // Unresolve the comment if it was previously resolved
-			if ec.Type == github.FileComment {
-				if err := f.client.UnresolveFileComment(ec); err != nil {
-					return err
-				}
-			} else {
-				if err := f.client.UnresolveComment(ec); err != nil {
-					return err
-				}
-			}
 			continue
 		}
 

--- a/formatters/githubformat/githubformat.go
+++ b/formatters/githubformat/githubformat.go
@@ -50,6 +50,10 @@ func (f *Formatter) BeforeAll(i *manifest.Import) error {
 	}
 
 	for _, comment := range comments {
+		// Ignore any comments that were previously resolved. New ones will be created if necessary
+		if strings.HasPrefix(comment.Body, "<strike>") {
+			continue;
+		}
 		matches := fingerprintRegex.FindAllStringSubmatch(comment.Body, -1)
 		for _, fingerprint := range matches {
 			f.existingComments[fingerprint[1]] = comment

--- a/formatters/githubformat/githubformat_test.go
+++ b/formatters/githubformat/githubformat_test.go
@@ -48,16 +48,6 @@ func (f *fakeGitHubClient) ResolveComment(comment github.Comment) error {
 	return args.Error(0)
 }
 
-func (f *fakeGitHubClient) UnresolveFileComment(comment github.Comment) error {
-	args := f.Called(comment)
-	return args.Error(0)
-}
-
-func (f *fakeGitHubClient) UnresolveComment(comment github.Comment) error {
-	args := f.Called(comment)
-	return args.Error(0)
-}
-
 func TestFormat_FileComment(t *testing.T) {
 	i := &manifest.Import{
 		Pull: &manifest.Pull{
@@ -166,8 +156,6 @@ func TestFormat_Deduplicates(t *testing.T) {
 	client.On("ReviewComments", 1).Return([]github.Comment{
 		{Body: "<!-- manifest:test:test.go:10:RIGHT -->", Type: github.FileComment},
 	}, nil)
-	client.On("UnresolveComment", mock.Anything).Return(nil)
-	client.On("UnresolveFileComment", mock.Anything).Return(nil)
 
 	formatter := New(io.Discard, client)
 	err := formatter.BeforeAll(i)
@@ -178,8 +166,6 @@ func TestFormat_Deduplicates(t *testing.T) {
 	client.AssertExpectations(t)
 
 	client.AssertNotCalled(t, "FileComment", mock.Anything)
-	client.AssertCalled(t, "UnresolveComment", mock.Anything)
-	client.AssertCalled(t, "UnresolveFileComment", mock.Anything)
 }
 
 func TestFormat_ResolveComment(t *testing.T) {


### PR DESCRIPTION
This PR removes the un-resolve funcationality and instead allows for the creation of a new issue. Unresolving an older comment might be a bit confusing, so it's better to create a new comment to address the issue.